### PR TITLE
Hg launcher issue 38

### DIFF
--- a/app/src/main/java/mono/hg/LauncherActivity.java
+++ b/app/src/main/java/mono/hg/LauncherActivity.java
@@ -291,8 +291,11 @@ public class LauncherActivity extends AppCompatActivity {
         if (!PreferenceHelper.keepAppList()) {
             doThis("dismiss_panel");
         } else {
-            // Clear the search bar text if app list is set to be kept open.
+            // Clear the search bar text if app list is set to be kept open
+            // unless keepLastSearch setting indicates maintain last search
+            if (!PreferenceHelper.keepLastSearch()) {
             searchBar.setText("");
+        }
         }
 
         Utils.unregisterPackageReceiver(this, packageReceiver);
@@ -931,7 +934,12 @@ public class LauncherActivity extends AppCompatActivity {
                 switch (newState) {
                     case SlidingUpPanelLayout.PanelState.DRAGGING:
                         // Empty out search bar text
+
+                        // Clear the search bar text if app list is set to be kept open
+                        // unless keepLastSearch setting indicates maintain last search
+                        if (!PreferenceHelper.keepLastSearch()) {
                         searchBar.setText(null);
+                        }
 
                         // Preemptive attempt at showing the keyboard.
                         if (PreferenceHelper.shouldFocusKeyboard()) {
@@ -1017,6 +1025,13 @@ public class LauncherActivity extends AppCompatActivity {
 
         pinnedAppString = newAppString;
     }
+
+    public void clearSearch(View v)
+    {
+        // Clear the search bar text if app list is set to be kept open
+        searchBar.setText("");
+    }
+
 
     /**
      * Creates a dialog to set an app's shorthand.

--- a/app/src/main/java/mono/hg/helpers/PreferenceHelper.java
+++ b/app/src/main/java/mono/hg/helpers/PreferenceHelper.java
@@ -23,6 +23,7 @@ public class PreferenceHelper {
     private static boolean web_search_enabled;
     private static boolean static_favourites_panel;
     private static boolean static_app_list;
+    private static boolean keep_last_search;
     private static boolean adaptive_shade;
     private static boolean windowbar_status_switch;
     private static boolean web_search_long_press;
@@ -116,6 +117,10 @@ public class PreferenceHelper {
 
     public static boolean keepAppList() {
         return static_app_list;
+    }
+
+    public static boolean keepLastSearch() {
+        return keep_last_search;
     }
 
     public static boolean wasAlien() {
@@ -309,6 +314,7 @@ public class PreferenceHelper {
         static_favourites_panel = getPreference().getBoolean("static_favourites_panel_switch",
                 false);
         static_app_list = getPreference().getBoolean("static_app_list_switch", false);
+        keep_last_search = getPreference().getBoolean("keep_last_search_switch", false);
         adaptive_shade = getPreference().getBoolean("adaptive_shade_switch", false);
         windowbar_status_switch = getPreference().getBoolean("windowbar_status_switch", false);
         windowbar_mode = getPreference().getString("windowbar_mode", "none");

--- a/app/src/main/res/layout/layout_searchbar.xml
+++ b/app/src/main/res/layout/layout_searchbar.xml
@@ -15,7 +15,7 @@
 
     <androidx.appcompat.widget.AppCompatEditText
         android:id="@+id/search"
-        android:layout_width="354dp"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/transparent"
         android:hint="@string/search_hint"

--- a/app/src/main/res/layout/layout_searchbar.xml
+++ b/app/src/main/res/layout/layout_searchbar.xml
@@ -15,7 +15,7 @@
 
     <androidx.appcompat.widget.AppCompatEditText
         android:id="@+id/search"
-        android:layout_width="match_parent"
+        android:layout_width="354dp"
         android:layout_height="match_parent"
         android:background="@android:color/transparent"
         android:hint="@string/search_hint"
@@ -28,5 +28,13 @@
         android:paddingRight="@dimen/uniform_panel_margin"
         android:textColor="@android:color/white"
         android:textColorHint="@color/editTextHint" />
+
+    <Button
+        android:id="@+id/clearSearch"
+        android:layout_width="40dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:onClick="clearSearch"
+        android:text="X" />
 
 </FrameLayout>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -20,6 +20,7 @@
     <string name="pref_summary_wall">Screen orientation, system bars mode</string>
     <string name="pref_summary_list">Hidden apps, icon pack, app list behaviors</string>
 
+
     <!-- Backup and restore -->
     <string name="pref_header_hidden_apps">Hidden apps</string>
     <string name="pref_header_hidden_apps_desc">Manage your list of hidden apps</string>
@@ -100,6 +101,9 @@
 
     <string name="static_app_list">Always open app list</string>
     <string name="static_app_list_desc">Open the app list when entering the launcher. This does not prevent it from being closed.</string>
+
+    <string name="app_list_keep_search_desc">Maintain the search text when launcher closes.</string>
+    <string name="app_list_keep_search">Maintain search text</string>
 
     <string name="pref_app_launch_anim">Launch animation</string>
     <string name="anim_list_default">System-defined</string>

--- a/app/src/main/res/xml/pref_app_list.xml
+++ b/app/src/main/res/xml/pref_app_list.xml
@@ -40,6 +40,12 @@
         android:summary="@string/static_app_list_desc"
         android:title="@string/static_app_list" />
 
+    <androidx.preference.SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="keep_last_search_switch"
+        android:summary="Maintain the search text when launcher closes..."
+        android:title="Maintain search text" />
+
     <mono.hg.wrappers.SpinnerPreference
         android:defaultValue="alphabetical"
         android:entries="@array/pref_app_list_order_titles"

--- a/app/src/main/res/xml/pref_app_list.xml
+++ b/app/src/main/res/xml/pref_app_list.xml
@@ -43,8 +43,8 @@
     <androidx.preference.SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="keep_last_search_switch"
-        android:summary="Maintain the search text when launcher closes..."
-        android:title="Maintain search text" />
+        android:summary="@string/app_list_keep_search_desc"
+        android:title="@string/app_list_keep_search" />
 
     <mono.hg.wrappers.SpinnerPreference
         android:defaultValue="alphabetical"


### PR DESCRIPTION
Hi, please consider this PR for inclusion.

- button on left of search text bar to clear search
- option in app list preferences to maintain search text when launcher is hidden/closed
- if option is "true", maintain search text on close/hide, etc.

I am not sure how aesthetically pleasing the clear button is (design isn't my strong suit).